### PR TITLE
feat: svelte-vega now exports VisualizationSpec

### DIFF
--- a/packages/sample-project/src/App.svelte
+++ b/packages/sample-project/src/App.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { VisualizationSpec } from "vega-embed";
   import { Vega, VegaLite } from "svelte-vega";
+  import type { VisualizationSpec } from "svelte-vega";
 
   let dataVL = {
     table: [

--- a/packages/svelte-vega/README.md
+++ b/packages/svelte-vega/README.md
@@ -49,8 +49,7 @@ For an example Svelte project using `svelte-vega`, see the [example application]
 
 ```typescript
 <script lang="ts">
-  import type { VisualizationSpec } from "vega-embed";
-
+  import type { VisualizationSpec } from "svelte-vega";
   import { Vega } from "svelte-vega";
 
   const data = {
@@ -77,8 +76,7 @@ For an example Svelte project using `svelte-vega`, see the [example application]
 
 ```typescript
 <script lang="ts">
-  import type { VisualizationSpec } from "vega-embed";
-
+  import type { VisualizationSpec } from "svelte-vega";
   import { VegaLite } from "svelte-vega";
 
   const data = {

--- a/packages/svelte-vega/src/Vega.svelte
+++ b/packages/svelte-vega/src/Vega.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { EmbedOptions, Mode, VisualizationSpec } from "vega-embed";
-  import type { SignalListeners } from "./types";
+  import type { EmbedOptions, Mode } from "vega-embed";
+  import type { SignalListeners, VisualizationSpec } from "./types";
   import VegaEmbed from "./VegaEmbed.svelte";
 
   export let spec: VisualizationSpec;

--- a/packages/svelte-vega/src/VegaEmbed.svelte
+++ b/packages/svelte-vega/src/VegaEmbed.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { createEventDispatcher, onDestroy } from "svelte";
-  import type { EmbedOptions, Result, VisualizationSpec } from "vega-embed";
+  import type { EmbedOptions, Result } from "vega-embed";
   import vegaEmbed from "vega-embed";
   import { WIDTH_HEIGHT } from "./constants";
-  import type { SignalListeners, View } from "./types";
+  import type { SignalListeners, View, VisualizationSpec } from "./types";
   import {
     addSignalListenersToView,
     updateMultipleDatasetsInView,

--- a/packages/svelte-vega/src/VegaLite.svelte
+++ b/packages/svelte-vega/src/VegaLite.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  import type { EmbedOptions, Mode, VisualizationSpec } from "vega-embed";
-  import type { SignalListeners } from "./types";
+  import type { EmbedOptions, Mode } from "vega-embed";
+  import type { SignalListeners, VisualizationSpec } from "./types";
   import VegaEmbed from "./VegaEmbed.svelte";
 
   export let spec: VisualizationSpec;

--- a/packages/svelte-vega/src/types.ts
+++ b/packages/svelte-vega/src/types.ts
@@ -1,4 +1,4 @@
-import type { Result } from "vega-embed";
+import type { Result, VisualizationSpec as Spec } from "vega-embed";
 
 export type View = Result["view"];
 
@@ -7,3 +7,5 @@ export type SignalListener = (name: string, value: unknown) => void;
 export type SignalListeners = {
   [key: string]: SignalListener;
 };
+
+export type VisualizationSpec = Spec;

--- a/packages/svelte-vega/src/types.ts
+++ b/packages/svelte-vega/src/types.ts
@@ -1,4 +1,6 @@
 import type { Result, VisualizationSpec as Spec } from "vega-embed";
+import type { Spec as VgSpec } from "vega";
+import type { TopLevelSpec as VlSpec } from "vega-lite";
 
 export type View = Result["view"];
 
@@ -9,3 +11,5 @@ export type SignalListeners = {
 };
 
 export type VisualizationSpec = Spec;
+export type VegaSpec = VgSpec;
+export type VegaLiteSpec = VlSpec;


### PR DESCRIPTION
Now exporting VisualizationSpec directly from svelte-vega, so no need to import vega-embed for that
anymore.

re #29