### PR TITLE
fix: warning when not providing view silenced

### DIFF
--- a/packages/svelte-vega/src/VegaLite.svelte
+++ b/packages/svelte-vega/src/VegaLite.svelte
@@ -3,11 +3,11 @@
   import type { SignalListeners, VisualizationSpec, View } from "./types";
   import VegaEmbed from "./VegaEmbed.svelte";
 
-  export let view: View | undefined;
   export let spec: VisualizationSpec;
   export let options: EmbedOptions = {};
   export let data: Record<string, unknown> = {};
   export let signalListeners: SignalListeners = {};
+  export let view: View | undefined = undefined;
 
   const mode = "vega-lite" as Mode;
   $: vegaLiteOptions = { ...options, mode: mode };


### PR DESCRIPTION
When not passing a view to VegaLite, one got a warning that it should not be initialized without a
view. This has been changed by initializing the view to undefined.