### PR TITLE
fix(kit): disable SSR because it does not work with vega-embed

### DIFF
--- a/packages/sveltekit-vega-sample/src/routes/+layout.server.ts
+++ b/packages/sveltekit-vega-sample/src/routes/+layout.server.ts
@@ -1,0 +1,1 @@
+export const ssr = false;


### PR DESCRIPTION
@domoritz not ideal but I think `json-stringify-pretty-compact` does not work with SSR. Could alternatively probably dynamically import but also not much better.