### PR TITLE
refactor(sveltekit-vega-sample): reenable SSR now that everything is esm

### DIFF
--- a/packages/sveltekit-vega-sample/src/routes/+layout.server.ts
+++ b/packages/sveltekit-vega-sample/src/routes/+layout.server.ts
@@ -1,1 +1,0 @@
-export const ssr = false;


### PR DESCRIPTION
Previously, ssr was broken. With the move of all vega packages to esm, this has been fixed. This PR reenables SSR for the sveltekit example.

fix #977 