### PR TITLE
build: update peer dependencies to esm-ready modules

### DIFF
--- a/packages/svelte-vega/package.json
+++ b/packages/svelte-vega/package.json
@@ -59,9 +59,9 @@
 	},
 	"peerDependencies": {
 		"svelte": "^5.0.0",
-		"vega": "*",
-		"vega-embed": "*",
-		"vega-lite": "*"
+		"vega": "^6.0.0",
+		"vega-embed": "^7.0.0",
+		"vega-lite": "^5.0.0"
 	},
 	"publishConfig": {
 		"access": "public"


### PR DESCRIPTION
This update makes sure that Vega-related peer depenencies' minimum versions are esm so that SSR does not fail when wrong versions of Vega packages are installed.